### PR TITLE
WIP: add pre2014 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `.rosinstall` file can then be used to build the set of ROS packages that wi
 ## Usage
 
 ```
-rosinstall_generator_tm.sh [ ISSUE_URL | ISO8601_DATETIME ] BUG_ID ROS_DISTRO PUT ROSINSTALL_FILENAME
+rosinstall_generator_tm.sh [ ISSUE_URL | ISO8601_DATETIME ] BUG_ID ROS_DISTRO PUT
 ```
 
 Example invocation to generate a `.rosinstall` file, based on an issue opened on the `yujinrobot/kobuki_core` tracker on the 1st of March 2017 (note reuse of the cache):
@@ -22,8 +22,7 @@ user@machine:~$ rosinstall_generator_tm.sh \
   https://github.com/yujinrobot/kobuki_core/issues/29 \
   eed104d \
   kinetic \
-  kobuki_ftdi \
-  deps_eed104d.rosinstall
+  kobuki_ftdi > deps.rosinstall
 Switched to branch 'master'
 Your branch is up-to-date with 'origin/master'.
 Retrieving issue 'created_at' property for: https://github.com/yujinrobot/kobuki_core/issues/29
@@ -31,6 +30,7 @@ Found: 2017-03-01T08:57:20Z
 Determined rosdistro commit: 2af311e205b874e862be155ffe21cb54e902f60b
 Reusing existing branch
 Switched to branch 'bughunt_eed104d'
+Detected post PR141 rosdistro Python lib
 Skipping rosdistro cache, already exists
 Creating temporary rosdistro index ..
 Using temporary index to generate rosinstall file (dependencies only) ..
@@ -46,45 +46,45 @@ user@machine:~$ rosinstall_generator_tm.sh \
   2017-03-01T08:57:20Z \
   eed104d \
   kinetic \
-  kobuki_ftdi \
-  deps_eed104d.rosinstall
+  kobuki_ftdi > deps.rosinstall
 ...
 ```
 
 **Note**: be prepared to press <kbd>RET</kbd> a few times for some repositories that no longer exist, or are now private repositories (and for which `git` would now need a password).
 
-This will generate the `deps_eed104d.rosinstall` file containing all dependencies (and only the dependencies) of the `kobuki_ftdi` package in ROS Kinetic at the time that `yujinrobot/kobuki_core/issues/29` was reported. It will also generate a yaml file containing some metadata (`ros/rosdistro` commit used, issue created stamp, ROS distribution, etc) and a directory containing the `rosdistro` cache that was used to generate the `.rosinstall` file.
+This will write to `deps.rosinstall` all dependencies (and only the dependencies) of the `kobuki_ftdi` package in ROS Kinetic at the time that `yujinrobot/kobuki_core/issues/29` was reported. It will also generate a yaml file containing some metadata (`ros/rosdistro` commit used, issue created stamp, ROS distribution, etc) and a directory containing the `rosdistro` cache that was used to generate the `.rosinstall` file.
 
 
 ## Requirements
 
-In order to be able to run this, the following need to be present:
+In order to be able to run this, two Python virtual environments are currently needed (this will change in future releases).
 
- - git
- - Python 2
- - `rosdistro` Python library ([this fork](https://github.com/rosin-project/rosdistro_python/tree/rosin_bughunt_0.6.8), `rosin_bughunt_0.6.8` branch)
- - `rosinstall_generator`
- - PyGitHub
-
-It is recommended to install these dependencies (ie: `rosdistro` and `rosinstall_generator`) in a Python virtual environment (order matters):
+To setup the "pre PR141" virtual environment:
 
 ```shell
-virtualenv ritm_venv
-source ritm_venv/bin/activate
-pip install -U pip
-pip install wheel
-pip install git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.6.8
-pip install rosinstall_generator
-pip install PyGitHub
+virtualenv -p python2 ritm_venv_pre141
+source ritm_venv_pre141/bin/activate
+pip install -U pip wheel
+pip install -r requirements_pre141.txt
 ```
 
-At this point the environment setup should be complete and the tool can be used. Do not forget to (re)activate the virtual environment again when needed.
+To setup the "post PR141" virtual environment (be sure to deactive the "pre 141" venv first if active):
+
+```shell
+virtualenv -p python2 ritm_venv_post141
+source ritm_venv_post141/bin/activate
+pip install -U pip wheel
+pip install -r requirements_post141.txt
+```
+
+At this point the environment setup should be complete and the tool can be used. Do not forget to (re)activate the correct virtual environment again when needed.
 
 
 ## Limitations
 
-The current implementation can only go back to 25th of January, 2014 (on that date updates to various packages including `rosdistro` and `rosinstall_generator` was rolled out for REP-141 compliance).
-It also cannot reuse any caches that are 'close' or 'near' in time to a previous cache right now, leading to the tool always (re)building a rosdistro cache, even if there is only a minor time difference between two subsequent `rosdistro` commits.
+The current implementation can only go back to a point in time before the `rosdistro` files were significantly changed. What that point is, is currently unclear. The previous limitation of not being able to go back to before PR141 `rosdistro` commits (2014-01-25) has been removed.
+
+The current implementation can also cannot reuse any caches that are 'close' or 'near' in time to a previous cache right now, leading to the tool always (re)building a rosdistro cache, even if there is only a minor time difference between two subsequent `rosdistro` commits. This will be fixed in a future enhancement.
 
 It (obviously) cannot provide information on repositories that no longer exist (this becomes more of a problem the further back in time one goes).
 
@@ -103,10 +103,6 @@ It (obviously) cannot provide information on repositories that no longer exist (
 ## FAQ
 
 Some frequently asked questions and answers.
-
-#### Date YYYY-MM-DDTHH:MM:SS too far in the past
-
-This error is printed whenever the script is asked to go back to a date that is beyond what is currently supported (25th of January 2014).
 
 #### No packages/stacks left after ignoring not released
 

--- a/requirements_post141.txt
+++ b/requirements_post141.txt
@@ -1,0 +1,3 @@
+git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.6.8#egg=rosdistro
+rosinstall_generator
+PyGitHub

--- a/requirements_pre141.txt
+++ b/requirements_pre141.txt
@@ -1,0 +1,5 @@
+git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.2.20#egg=rosdistro
+rosinstall==0.7.2
+rosdep==0.10.24
+rosinstall_generator==0.1.5
+PyGitHub


### PR DESCRIPTION
This adds a version of pre 2014 support to the time machine.

I'm not too happy with it, as users need to already know whether they want to generate a `.rosinstall` file from before Jan 2014.

This will all be fixed in a potential Python rewrite.
