### PR TITLE
Use rebased rosdistro patch, improve image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN virtualenv -p python2.7 pre141 \
 
 # setup pre venv
 # use older version of setuptools or things won't build
-RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
+RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U 'pip<21.0' \
  && /rgtm/pre141/bin/pip --no-python-version-warning install -U wheel setuptools==20.1.1 \
  && /rgtm/pre141/bin/pip --no-python-version-warning install nose==1.3.7 \
  && /rgtm/pre141/bin/pip --no-python-version-warning install \
@@ -52,7 +52,7 @@ RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
  && rm -rf /root/.cache/pip
 
 # setup post venv
-RUN /rgtm/post141/bin/pip --no-python-version-warning install -U pip \
+RUN /rgtm/post141/bin/pip --no-python-version-warning install -U 'pip<21.0' \
  && /rgtm/post141/bin/pip --no-python-version-warning install -U wheel setuptools==44.0.0 \
  && /rgtm/post141/bin/pip --no-python-version-warning install \
       git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.8.3_test#egg=rosdistro \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
 RUN /rgtm/post141/bin/pip --no-python-version-warning install -U pip \
  && /rgtm/post141/bin/pip --no-python-version-warning install -U wheel setuptools==44.0.0 \
  && /rgtm/post141/bin/pip --no-python-version-warning install \
-      git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.6.8#egg=rosdistro \
+      git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.8.3_test#egg=rosdistro \
       rosinstall_generator \
  && rm -rf /root/.cache/pip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,9 @@ RUN virtualenv -p python2.7 pre141 \
 
 # setup pre venv
 # use older version of setuptools or things won't build
-RUN /rgtm/pre141/bin/pip install -U pip \
- && /rgtm/pre141/bin/pip install -U wheel setuptools==20.1.1 \
- && /rgtm/pre141/bin/pip install \
+RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
+ && /rgtm/pre141/bin/pip --no-python-version-warning install -U wheel setuptools==20.1.1 \
+ && /rgtm/pre141/bin/pip --no-python-version-warning install \
       git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.2.20#egg=rosdistro \
       rosinstall==0.7.2 \
       rosdep==0.10.24 \
@@ -51,9 +51,9 @@ RUN /rgtm/pre141/bin/pip install -U pip \
  && rm -rf /root/.cache/pip
 
 # setup post venv
-RUN /rgtm/post141/bin/pip install -U pip \
- && /rgtm/post141/bin/pip install -U wheel setuptools==44.0.0 \
- && /rgtm/post141/bin/pip install \
+RUN /rgtm/post141/bin/pip --no-python-version-warning install -U pip \
+ && /rgtm/post141/bin/pip --no-python-version-warning install -U wheel setuptools==44.0.0 \
+ && /rgtm/post141/bin/pip --no-python-version-warning install \
       git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.6.8#egg=rosdistro \
       rosinstall_generator \
  && rm -rf /root/.cache/pip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN virtualenv -p python2.7 pre141 \
 # use older version of setuptools or things won't build
 RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
  && /rgtm/pre141/bin/pip --no-python-version-warning install -U wheel setuptools==20.1.1 \
+ && /rgtm/pre141/bin/pip --no-python-version-warning install nose==1.3.7 \
  && /rgtm/pre141/bin/pip --no-python-version-warning install \
       git+https://github.com/rosin-project/rosdistro_python@rosin_bughunt_0.2.20#egg=rosdistro \
       rosinstall==0.7.2 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN /rgtm/pre141/bin/pip --no-python-version-warning install -U pip \
       rospkg==1.2.3 \
       distribute==0.7.3 \
       pyyaml==5.3 \
-      vcstools==0.1.30 \
+      vcstools==0.1.38 \
  && rm -rf /root/.cache/pip
 
 # setup post venv


### PR DESCRIPTION
This was prompted by #18, and a bit of #17.

It's unclear whether the rebased `rosdistro` patch is working correctly, so for now this is just a 'test' PR.

Ideally we'd pin the versions of dependencies in `post141`, so we prevent build issues in the future. But for now I don't know which versions actually work, so this PR doesn't include that yet.
